### PR TITLE
Use the coreos maintained fork of boltdb.

### DIFF
--- a/bolthelper.go
+++ b/bolthelper.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golangplus/bytes"
 	"github.com/golangplus/errors"
 
-	"github.com/boltdb/bolt"
+	"github.com/coreos/bbolt"
 )
 
 // A wrapper to *bolt.DB.


### PR DESCRIPTION
Use the coreos maintained fork of boltdb.